### PR TITLE
Add iOS EAS build/release scripts and README instructions for non-interactive builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,20 @@ A React Native / Expo app for cross-platform manga reading
 
 Android: [here](./onigiri.apk)
 
+## Build for iOS
+
+From the repo root, trigger an EAS iOS build with:
+
+```bash
+yarn workspace @onigiri/expo build:development:ios
+```
+
+If you are running in CI/non-interactive mode, log in with an Expo token first and use:
+
+```bash
+EXPO_TOKEN=<your_token> yarn workspace @onigiri/expo build:development:ios --non-interactive
+```
+
 ## Questions?
 
 Feel free to create new issue: https://github.com/hahunavth/comic-net-native/issues

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -28,7 +28,10 @@
     "build:preview:android": "STAGE=staging eas build --profile preview --platform android",
     "build:production": "STAGE=production eas build --profile production --platform all",
     "build:production:ios": "STAGE=production eas build --profile production --platform ios",
-    "build:production:android": "STAGE=production eas build --profile production --platform android"
+    "build:production:android": "STAGE=production eas build --profile production --platform android",
+    "build:production:ios:non-interactive": "STAGE=production eas build --profile production --platform ios --non-interactive",
+    "upload:production:ios": "STAGE=production eas submit --platform ios --latest --non-interactive",
+    "release:production:ios": "yarn build:production:ios:non-interactive && yarn upload:production:ios"
   },
   "dependencies": {
     "@babel/helper-environment-visitor": "^7.16.7",


### PR DESCRIPTION
### Motivation
- Add documented instructions for building the iOS app via EAS and support non-interactive CI-friendly workflows.
- Provide npm scripts to automate production iOS build and submission to simplify CI release steps.

### Description
- Add a `Build for iOS` section to `README.md` with examples for running `yarn workspace @onigiri/expo build:development:ios` and using `EXPO_TOKEN` for non-interactive CI mode.
- Add three npm scripts to `packages/expo/package.json`: `build:production:ios:non-interactive`, `upload:production:ios`, and `release:production:ios` to enable non-interactive production builds and submission via `eas` and `eas submit`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eff36c73d083298420c1ecb56ee1d4)